### PR TITLE
Convert to Ruby/Postgres backend with React client

### DIFF
--- a/Dockerfile.ruby
+++ b/Dockerfile.ruby
@@ -1,0 +1,6 @@
+FROM ruby:3.1
+WORKDIR /app
+COPY ruby-app/Gemfile ruby-app/Gemfile.lock* ./
+RUN bundle install
+COPY ruby-app .
+CMD ["bundle", "exec", "ruby", "app.rb", "-p", "4567", "-o", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,20 @@
 version: '3'
 services:
-  app:
-    build: .
-    ports:
-      - "8080:8080"
-    depends_on:
-      - mongo
-  mongo:
-    image: mongo
-    ports:
-      - "27017:27017"
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.ruby
     volumes:
-      - ./data:/data/db
+      - ./ruby-app:/app
+    ports:
+      - "4567:4567"
+    depends_on:
+      - db
+  db:
+    image: postgres:13
+    environment:
+      POSTGRES_DB: timetable_development
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+    ports:
+      - "5432:5432"

--- a/ruby-app/Gemfile
+++ b/ruby-app/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'sinatra'
+gem 'sinatra-activerecord'
+gem 'pg'

--- a/ruby-app/Rakefile
+++ b/ruby-app/Rakefile
@@ -1,0 +1,2 @@
+require 'sinatra/activerecord/rake'
+require './app'

--- a/ruby-app/app.rb
+++ b/ruby-app/app.rb
@@ -1,0 +1,22 @@
+require 'sinatra'
+require 'sinatra/activerecord'
+require 'json'
+
+set :database_file, 'config/database.yml'
+
+class Event < ActiveRecord::Base
+end
+
+get '/events' do
+  content_type :json
+  Event.all.to_json
+end
+
+post '/events' do
+  event = Event.create(JSON.parse(request.body.read))
+  event.to_json
+end
+
+get '/' do
+  send_file File.join(settings.public_folder, 'index.html')
+end

--- a/ruby-app/config.ru
+++ b/ruby-app/config.ru
@@ -1,0 +1,2 @@
+require './app'
+run Sinatra::Application

--- a/ruby-app/config/database.yml
+++ b/ruby-app/config/database.yml
@@ -1,0 +1,8 @@
+development:
+  adapter: postgresql
+  encoding: unicode
+  database: timetable_development
+  pool: 5
+  host: db
+  username: postgres
+  password: password

--- a/ruby-app/db/migrate/20240101000000_create_events.rb
+++ b/ruby-app/db/migrate/20240101000000_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[6.1]
+  def change
+    create_table :events do |t|
+      t.string :name
+      t.string :date
+      t.string :time
+      t.string :stage
+    end
+  end
+end

--- a/ruby-app/public/app.js
+++ b/ruby-app/public/app.js
@@ -1,0 +1,21 @@
+class App extends React.Component {
+  state = { events: [] };
+  componentDidMount() {
+    fetch('/events')
+      .then(r => r.json())
+      .then(events => this.setState({ events }));
+  }
+  render() {
+    return (
+      <div>
+        <h1>Timetable</h1>
+        <ul>
+          {this.state.events.map(e => (
+            <li key={e.id}>{e.name} - {e.date} {e.time} ({e.stage})</li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+}
+ReactDOM.render(<App />, document.getElementById('root'));

--- a/ruby-app/public/index.html
+++ b/ruby-app/public/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Timetable</title>
+    <script src="https://unpkg.com/react@17/umd/react.development.js"></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add Dockerfile.ruby to run Sinatra
- replace docker-compose to use Ruby web app and Postgres
- implement Sinatra app with ActiveRecord
- include migration and database config
- add simple React frontend served from Ruby

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684d944e10b4832b968b09c8fef4534f